### PR TITLE
PL-21820 Run deploy on branch main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,10 @@ jobs:
   include:
     - stage: gem release
       rvm: 3.2.1
-      if: type != pull_request && branch = main
+      if: type != pull_request
       script: skip
       deploy:
         provider: script
         script: ./bin/travis_deploy.sh
+        on:
+          branch: main


### PR DESCRIPTION
Hopefully the last iteration on this. Travis still [thinks](https://docs.travis-ci.com/user/deployment-v2/conditional#branch) `master` is the correct name for a github default branch, so we need to explicitly tell it to deploy from `main`.